### PR TITLE
Support inline queries

### DIFF
--- a/__tests__/__snapshots__/format.js.snap
+++ b/__tests__/__snapshots__/format.js.snap
@@ -32,6 +32,8 @@ exports[`telegraf-update-logger/lib/format export default function format it wor
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is in super group 1`] = `"[4] Test Supergroup: Foo Bar: message"`;
 
+exports[`telegraf-update-logger/lib/format export default function format it works when message is inline query 1`] = `"[(inline) 30] Foo Bar: inline query"`;
+
 exports[`telegraf-update-logger/lib/format export default function format it works when message is left chat member 1`] = `"[25] Test Group: Foo Bar: removed Baz"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is location 1`] = `"[21] Foo Bar: location on 50.450091 30.523415"`;

--- a/__tests__/testUpdates.json
+++ b/__tests__/testUpdates.json
@@ -767,5 +767,20 @@
       "date": 1426325213,
       "unknown_message_type": { "some": "thing" }
     }
+  },
+
+  "inline query": {
+    "update_id": 30,
+    "inline_query": {
+      "id": 30,
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "query": "inline query",
+      "offset": ""
+    }
   }
 }

--- a/lib/format.js
+++ b/lib/format.js
@@ -48,8 +48,6 @@ function format(update, options) {
     if (id != null) {
       return colors.id(`(inline) ${id}`);
     }
-
-    return undefined;
   }
 
   function formatChat({ title }) {

--- a/lib/format.js
+++ b/lib/format.js
@@ -26,6 +26,7 @@ function format(update, options) {
     update.edited_message ||
     update.channel_post ||
     update.edited_channel_post ||
+    update.inline_query ||
     update.callback_query;
 
   // (from the Telegram API docs):
@@ -39,8 +40,16 @@ function format(update, options) {
       ? DEFAULT_COLORS
       : DISABLED_COLORS;
 
-  function formatMessageID({ message_id }) {
-    return colors.id(message_id);
+  function formatMessageID({ message_id, id }) {
+    if (message_id != null) {
+      return colors.id(message_id);
+    }
+
+    if (id != null) {
+      return colors.id(`(inline) ${id}`);
+    }
+
+    return undefined;
   }
 
   function formatChat({ title }) {
@@ -83,6 +92,7 @@ function format(update, options) {
     left_chat_member,
     new_chat_title,
     new_chat_photo,
+    query,
   }) {
     let str = '';
 
@@ -106,6 +116,8 @@ function format(update, options) {
       str += `changed chat title`;
     } else if (new_chat_photo) {
       str += `changed chat photo`;
+    } else if (query) {
+      str += query;
     } else {
       const msgType = getMessageType(msg);
       str += colors.type(msgType || 'message');
@@ -119,7 +131,7 @@ function format(update, options) {
 
   let str = `[${formatMessageID(originalMessage || msg)}]`;
 
-  const chat = formatChat((originalMessage || msg).chat);
+  const chat = formatChat((originalMessage || msg).chat || {});
   if (chat) str += ` ${chat}:`;
   const sender = formatSender(msg);
   if (sender) str += ` ${sender}`;

--- a/lib/format.js
+++ b/lib/format.js
@@ -48,6 +48,8 @@ function format(update, options) {
     if (id != null) {
       return colors.id(`(inline) ${id}`);
     }
+
+    return null;
   }
 
   function formatChat({ title }) {


### PR DESCRIPTION
Logger crashes when user activates [inline mode](https://core.telegram.org/bots/inline) for bot (i.e. types `@botname` in chat)

Reason:
```
TypeError: Cannot read property 'message' of undefined
    at format (telegraf-update-logger\lib\format.js:33:31)
```

Current workaround: use `filter` option to exclude `inline_query` updates
```
updateLogger({
  filter: update => !update.inline_query,
})
```

This PR tries to fix it and log proper message using [InlineQuery](https://core.telegram.org/bots/api#inlinequery) `id` and `query` fields