### PR TITLE
feat: support Bot API 5.1 update types

### DIFF
--- a/__tests__/__snapshots__/format.js.snap
+++ b/__tests__/__snapshots__/format.js.snap
@@ -8,6 +8,8 @@ exports[`telegraf-update-logger/lib/format export default function format it wor
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is audio with caption 1`] = `"[16] Foo Bar: document, caption"`;
 
+exports[`telegraf-update-logger/lib/format export default function format it works when message is callback query with game 1`] = `"[(callback query) 0123456789876543210] Foo Bar: game: game_short_name"`;
+
 exports[`telegraf-update-logger/lib/format export default function format it works when message is callback query without chat title 1`] = `"[6] Foo Bar: action: some_action"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is callback query without data 1`] = `"[6] Test Channel: Foo Bar"`;
@@ -17,6 +19,10 @@ exports[`telegraf-update-logger/lib/format export default function format it wor
 exports[`telegraf-update-logger/lib/format export default function format it works when message is channel post 1`] = `"[5] Test Channel:: message"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is channel post with author signature 1`] = `"[6] Test Channel: Foo Bar: message"`;
+
+exports[`telegraf-update-logger/lib/format export default function format it works when message is chat member 1`] = `"[(chat member)]: Foo Bar changed status of Baz from 'member' to 'kicked'"`;
+
+exports[`telegraf-update-logger/lib/format export default function format it works when message is chat member without status change 1`] = `"[(chat member)]: Foo Bar changed Baz"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is chosen inline result 1`] = `"chosen inline result: Foo Bar chose 1 via query: inline query"`;
 
@@ -55,6 +61,10 @@ exports[`telegraf-update-logger/lib/format export default function format it wor
 exports[`telegraf-update-logger/lib/format export default function format it works when message is left chat member 1`] = `"[25] Test Group: Foo Bar: removed Baz"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is location 1`] = `"[21] Foo Bar: location on 50.450091 30.523415"`;
+
+exports[`telegraf-update-logger/lib/format export default function format it works when message is my chat member 1`] = `"[(my chat member)]: Foo Bar changed status of TestBot from 'member' to 'kicked'"`;
+
+exports[`telegraf-update-logger/lib/format export default function format it works when message is my chat member without status change 1`] = `"[(my chat member)]: Foo Bar changed TestBot"`;
 
 exports[`telegraf-update-logger/lib/format export default function format it works when message is new chat members 1`] = `"[24] Test Group: Foo Bar: added Baz"`;
 

--- a/__tests__/testUpdates.json
+++ b/__tests__/testUpdates.json
@@ -1145,5 +1145,140 @@
     "unsupported_type": {
       "id": "1"
     }
+  },
+
+  "my chat member": {
+    "update_id": 50,
+    "my_chat_member": {
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "date": 1615314618,
+      "old_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": true,
+          "first_name": "TestBot",
+          "username": "testbot"
+        },
+        "status": "member"
+      },
+      "new_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": true,
+          "first_name": "TestBot",
+          "username": "testbot"
+        },
+        "status": "kicked"
+      }
+    }
+  },
+
+  "my chat member without status change": {
+    "update_id": 51,
+    "my_chat_member": {
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "date": 1615314618,
+      "old_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": true,
+          "first_name": "TestBot",
+          "username": "testbot"
+        },
+        "status": "member"
+      },
+      "new_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": true,
+          "first_name": "TestBot",
+          "username": "testbot"
+        },
+        "status": "member"
+      }
+    }
+  },
+
+  "chat member": {
+    "update_id": 51,
+    "chat_member": {
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "date": 1615314618,
+      "old_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": false,
+          "first_name": "Baz"
+        },
+        "status": "member"
+      },
+      "new_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": false,
+          "first_name": "Baz"
+        },
+        "status": "kicked"
+      }
+    }
+  },
+
+  "chat member without status change": {
+    "update_id": 51,
+    "chat_member": {
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "date": 1615314618,
+      "old_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": false,
+          "first_name": "Baz"
+        },
+        "status": "member"
+      },
+      "new_chat_member": {
+        "user": {
+          "id": 456,
+          "is_bot": false,
+          "first_name": "Baz"
+        },
+        "status": "member"
+      }
+    }
+  },
+
+  "callback query with game": {
+    "update_id": 52,
+    "callback_query": {
+      "id": "0123456789876543210",
+      "from": {
+        "id": 123,
+        "is_bot": false,
+        "first_name": "Foo",
+        "last_name": "Bar"
+      },
+      "chat_instance": "9876543210123456789",
+      "game_short_name": "game_short_name"
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegraf-update-logger",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Update logging middleware for Telegraf",
   "repository": "https://github.com/dmitmel/telegraf-update-logger",
   "bugs": "https://github.com/dmitmel/telegraf-update-logger/issues",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.0",
-    "typegram": "^3.1.9"
+    "typegram": "^3.2.0"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.15.0",

--- a/src/format.ts
+++ b/src/format.ts
@@ -211,6 +211,42 @@ function format(update: tg.Update, options?: format.Options | null): string {
     return str;
   }
 
+  if ('my_chat_member' in update) {
+    const sender = update.my_chat_member.from;
+    const oldChatMember = update.my_chat_member.old_chat_member;
+    const newChatMember = update.my_chat_member.new_chat_member;
+
+    let str = `[${colors.type('(my chat member)')}]: ${formatUser(sender)}`;
+
+    if (oldChatMember.status !== newChatMember.status) {
+      str += ` changed status of ${formatUser(newChatMember.user)}`;
+      str += ` from '${colors.type(oldChatMember.status)}'`;
+      str += ` to '${colors.type(newChatMember.status)}'`;
+      return str;
+    }
+
+    str += ` changed ${formatUser(newChatMember.user)}`;
+    return str;
+  }
+
+  if ('chat_member' in update) {
+    const sender = update.chat_member.from;
+    const oldChatMember = update.chat_member.old_chat_member;
+    const newChatMember = update.chat_member.new_chat_member;
+
+    let str = `[${colors.type('(chat member)')}]: ${formatUser(sender)}`;
+
+    if (oldChatMember.status !== newChatMember.status) {
+      str += ` changed status of ${formatUser(newChatMember.user)}`;
+      str += ` from '${colors.type(oldChatMember.status)}'`;
+      str += ` to '${colors.type(newChatMember.status)}'`;
+      return str;
+    }
+
+    str += ` changed ${formatUser(newChatMember.user)}`;
+    return str;
+  }
+
   return 'unsupported update type';
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4005,10 +4005,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typegram@^3.1.9:
-  version "3.1.9"
-  resolved "https://registry.yarnpkg.com/typegram/-/typegram-3.1.9.tgz#9fd40956263f852b94c808f814ade61593089810"
-  integrity sha512-qF1cR8W7pm9oohLYPwH8jPZY3dRgA3/jjx0O83sKYHg1RYxIO90oEKH5FmnMq0lhGtX75pH0XOtyIU5e7hve4Q==
+typegram@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/typegram/-/typegram-3.2.0.tgz#edc8225451a6f9232f2aed21bea401805d083050"
+  integrity sha512-Pi8FtelaMfPXQIRdiAL9SiFaHYdttQS1eLQj2lNBbb0qM+PD/ttrv+u4Ea7z9mVA5Pc60LFj79Qqz06pIJrLdQ==
 
 typescript@^4.1.5:
   version "4.1.5"


### PR DESCRIPTION
This PR adds support for new update types from Bot API 5.1:

If everything is ok, please make a new release `1.5.0`